### PR TITLE
[DOC] Improves Kernel#yield_self docs example

### DIFF
--- a/object.c
+++ b/object.c
@@ -520,7 +520,10 @@ rb_obj_size(VALUE self, VALUE args, VALUE obj)
  *
  *  Yields <i>obj</i> and returns the result.
  *
- *	'my string'.yield_self {|s|s.upcase} #=> "MY STRING"
+ *     require "ostruct"
+ *     OpenStruct
+ *      .new(firstname: "John", lastname: "Doe")
+ *      .yield_self { |u| "#{u.firstname} #{u.lastname}" } #=> "John Doe"
  *
  */
 


### PR DESCRIPTION
Improves `Kernel#yield_self` docs example.

The intention of `Kernel#yield_self` might not be obvious from the current example, because

```ruby
'my string'.yield_self {|s|s.upcase}
```

can be simply replaced with 

```ruby
'my string'.upcase
```